### PR TITLE
added fine-grained access permission

### DIFF
--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -1,5 +1,8 @@
 name: GitHub-Profile-3D-Contrib
 
+permissions:
+  contents: write
+
 on:
   schedule: # 03:00 JST == 18:00 UTC
     - cron: "0 18 * * *"

--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -2,6 +2,9 @@
 
 name: Generate Snake
 
+permissions:
+  contents: write
+
 # Controls when the action will run. This action runs every 6 hours.
 
 on:


### PR DESCRIPTION
I suggest to give write permissions per each workflow as suggested. This way, you can avoid to set generic write permissions to *all* workflows.